### PR TITLE
Fix headers values

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -42,7 +42,7 @@ let setResponse (ctx: HttpContext) (response: HttpResponseMessage) = task {
     ctx.Response.StatusCode <- int response.StatusCode
     
     for KeyValue(name, value) in response.Headers do
-        ctx.SetHttpHeader(name, value)
+        ctx.SetHttpHeader(name, String.concat ";" value)
     
     return! ctx.WriteStreamAsync(
                 enableRangeProcessing = false,


### PR DESCRIPTION
before:
```
< Date: System.String[]
< Server: System.String[]
< Content-Length: 183
< Cache-Control: System.String[]
< Access-Control-Allow-Origin: System.String[]
< X-AspNetMvc-Version: System.String[]
< X-AspNet-Version: System.String[]
< X-Powered-By: System.String[]
```

after
```
< Date: Tue, 27 Apr 2021 17:27:17 GMT
< Server: Microsoft-IIS/8.5
< Content-Length: 183
< Cache-Control: private
< Access-Control-Allow-Origin: *
< X-AspNetMvc-Version: 5.2
< X-AspNet-Version: 4.0.30319
< X-Powered-By: ASP.NET
```